### PR TITLE
Apply the DRY principle and add better formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .idea
 icons
-.prettierrc

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 icons
+.prettierrc

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,21 @@
+{
+    "printWidth": 80,
+    "tabWidth": 4,
+    "useTabs": false,
+    "semi": true,
+    "singleQuote": true,
+    "quoteProps": "as-needed",
+    "jsxSingleQuote": true,
+    "trailingComma": "es5",
+    "bracketSpacing": true,
+    "bracketSameLine": false,
+    "jsxBracketSameLine": false,
+    "arrowParens": "avoid",
+    "rangeStart": 0,
+    "requirePragma": false,
+    "insertPragma": false,
+    "proseWrap": "preserve",
+    "htmlWhitespaceSensitivity": "css",
+    "endOfLine": "lf",
+    "embeddedLanguageFormatting": "auto"
+}

--- a/popup.js
+++ b/popup.js
@@ -87,17 +87,9 @@ const translator =
             .map(s => {
                 if (s === ' ') return ' ';
                 if (lang === 'fa') {
-                    return enToFaDictionary.hasOwnProperty(s)
-                        ? enToFaDictionary[s]
-                        : faToEnDictionary.hasOwnProperty(s)
-                        ? faToEnDictionary[s]
-                        : s;
+                    return faToEnDictionary[s] || enToFaDictionary[s] || s;
                 }
-                return faToEnDictionary.hasOwnProperty(s)
-                    ? faToEnDictionary[s]
-                    : enToFaDictionary.hasOwnProperty(s)
-                    ? enToFaDictionary[s]
-                    : s;
+                return faToEnDictionary[s] || enToFaDictionary[s] || s;
             })
             .join('');
 

--- a/popup.js
+++ b/popup.js
@@ -1,4 +1,4 @@
-console.log('https://github.com/hadizz')
+console.log('https://github.com/hadizz');
 
 const wrongInput = document.getElementById('wrong');
 const validInput = document.getElementById('valid');
@@ -8,167 +8,109 @@ let translatorLanguage = 'fa';
 const copyButton = document.getElementById('copy');
 
 const enToFaDictionary = {
-    'q': 'ض',
-    'Q': 'ْ',
-    'w': 'ص',
-    'W': 'ٌ',
-    'e': 'ث',
-    'E': 'ٍ',
-    'r': 'ق',
-    'R': 'ً',
-    't': 'ف',
-    'T': 'ُ',
-    'y': 'غ',
-    'Y': 'ِ',
-    'u': 'ع',
-    'U': 'َ',
-    'i': 'ه',
-    'I': 'ّ',
-    'o': 'خ',
-    'O': ']',
-    'p': 'ح',
-    'P': '}',
+    q: 'ض',
+    Q: 'ْ',
+    w: 'ص',
+    W: 'ٌ',
+    e: 'ث',
+    E: 'ٍ',
+    r: 'ق',
+    R: 'ً',
+    t: 'ف',
+    T: 'ُ',
+    y: 'غ',
+    Y: 'ِ',
+    u: 'ع',
+    U: 'َ',
+    i: 'ه',
+    I: 'ّ',
+    o: 'خ',
+    O: ']',
+    p: 'ح',
+    P: '}',
     '[': 'ج',
     '{': '}',
     ']': 'چ',
     '}': '{',
-    'a': 'ش',
-    'A': 'ؤ',
-    's': 'س',
-    'S': 'ئ',
-    'd': 'ی',
-    'D': 'ي',
-    'f': 'ب',
-    'F': 'إ',
-    'g': 'ل',
-    'G': 'أ',
-    'h': 'ا',
-    'H': 'آ',
-    'j': 'ت',
-    'J': 'ة',
-    'k': 'ن',
-    'K': '»',
-    'l': 'م',
-    'L': '«',
+    a: 'ش',
+    A: 'ؤ',
+    s: 'س',
+    S: 'ئ',
+    d: 'ی',
+    D: 'ي',
+    f: 'ب',
+    F: 'إ',
+    g: 'ل',
+    G: 'أ',
+    h: 'ا',
+    H: 'آ',
+    j: 'ت',
+    J: 'ة',
+    k: 'ن',
+    K: '»',
+    l: 'م',
+    L: '«',
     ';': 'ک',
     ':': ':',
-    '\'': 'گ',
+    "'": 'گ',
     '"': '؛',
-    'z': 'ظ',
-    'Z': 'ك',
-    'x': 'ط',
-    'X': 'ٓ',
-    'c': 'ز',
-    'C': 'ژ',
-    'v': 'ر',
-    'V': 'ٰ',
-    'b': 'ذ',
-    'B': '‌',
-    'n': 'د',
-    'N': 'ٔ',
-    'm': 'پ',
-    'M': 'ء',
+    z: 'ظ',
+    Z: 'ك',
+    x: 'ط',
+    X: 'ٓ',
+    c: 'ز',
+    C: 'ژ',
+    v: 'ر',
+    V: 'ٰ',
+    b: 'ذ',
+    B: '‌',
+    n: 'د',
+    N: 'ٔ',
+    m: 'پ',
+    M: 'ء',
     ',': 'و',
     '<': '<',
     '?': '؟',
 };
 
-const faToEnDictionary = {
-    'ض': 'q',
-    'ْ': 'Q',
-    'ص': 'w',
-    'ٌ': 'W',
-    'ث': 'e',
-    'ٍ': 'E',
-    'ق': 'r',
-    'ً': 'R',
-    'ف': 't',
-    'ُ': 'T',
-    'غ': 'y',
-    'ِ': 'Y',
-    'ع': 'u',
-    'َ': 'U',
-    'ه': 'i',
-    'ّ': 'I',
-    'خ': 'o',
-    ']': 'O',
-    'ح': 'p',
-    '[': 'P',
-    'ج': '[',
-    '}': '{',
-    'چ': ']',
-    '{': '}',
-    'ش': 'a',
-    'ؤ': 'A',
-    'س': 's',
-    'ئ': 'S',
-    'ی': 'd',
-    'ي': 'D',
-    'ب': 'f',
-    'إ': 'F',
-    'ل': 'g',
-    'أ': 'G',
-    'ا': 'h',
-    'آ': 'H',
-    'ت': 'j',
-    'ة': 'J',
-    'ن': 'k',
-    '»': 'K',
-    'م': 'l',
-    '«': 'L',
-    'ک': ';',
-    ':': ':',
-    'گ': '\'',
-    '؛': '"',
-    'ظ': 'z',
-    'ك': 'Z',
-    'ط': 'x',
-    'ٓ': 'X',
-    'ز': 'c',
-    'ژ': 'C',
-    'ر': 'v',
-    'ٰ': 'V',
-    'ذ': 'b',
-    '‌': 'B',
-    'د': 'n',
-    'ٔ': 'N',
-    'پ': 'm',
-    'ء': 'M',
-    'و': ',',
-    '<': '<',
-    '.': '.',
-    '>': '>',
-    '/': '/',
-    '؟': '?',
-};
+const faToEnDictionary = {};
+for (let key in enToFaDictionary) {
+    faToEnDictionary[enToFaDictionary[key]] = key;
+}
 
-const translator = (lang = 'fa') => str =>
-    str
-        .trim()
-        .split('')
-        .map(s => {
-            if (s === ' ') return ' ';
-            if (lang === 'fa') {
-                return enToFaDictionary.hasOwnProperty(s) ? enToFaDictionary[s] :
-                    faToEnDictionary.hasOwnProperty(s) ? faToEnDictionary[s] :
-                        s;
-            }
-            return faToEnDictionary.hasOwnProperty(s) ? faToEnDictionary[s] :
-                enToFaDictionary.hasOwnProperty(s) ? enToFaDictionary[s] :
-                    s;
-        }).join('');
+const translator =
+    (lang = 'fa') =>
+    str =>
+        str
+            .trim()
+            .split('')
+            .map(s => {
+                if (s === ' ') return ' ';
+                if (lang === 'fa') {
+                    return enToFaDictionary.hasOwnProperty(s)
+                        ? enToFaDictionary[s]
+                        : faToEnDictionary.hasOwnProperty(s)
+                        ? faToEnDictionary[s]
+                        : s;
+                }
+                return faToEnDictionary.hasOwnProperty(s)
+                    ? faToEnDictionary[s]
+                    : enToFaDictionary.hasOwnProperty(s)
+                    ? enToFaDictionary[s]
+                    : s;
+            })
+            .join('');
 
 wrongInput?.addEventListener('input', event => {
     const str = event.target.value;
     validInput.value = translator(translatorLanguage)(str);
-})
+});
 
-validInput?.addEventListener('change', event => {
-})
+validInput?.addEventListener('change', event => {});
 
 copyButton?.addEventListener('click', () => {
     const copyText = validInput.value.trim();
-    const message = document.getElementById('copyMessage')
+    const message = document.getElementById('copyMessage');
 
     if (!!copyText) {
         validInput.select();
@@ -176,7 +118,7 @@ copyButton?.addEventListener('click', () => {
 
         navigator.clipboard.writeText(copyText);
 
-        message.textContent = 'کپی شد!'
-        setTimeout(() => message.textContent = '', 2000);
+        message.textContent = 'کپی شد!';
+        setTimeout(() => (message.textContent = ''), 2000);
     }
-})
+});


### PR DESCRIPTION
### 2 big objects
`enToFaDictionary` and `faToEnDictionary` are 2 big objects. With their **keys** and **values** being the exact reversed version of each other! So by reversing one (in this case `enToFaDictionary`) and assigning it to the other, we still get the same result only with much fewer lines of code (63 to be exact).
**Side Note**: This could be accomplished using `Array.reduce` method and more advance ES6 features as well. A `for` loop is the simplest one.


### using quotes for object keys
unless you want to use a key that’s not a valid JavaScript identifier, wrapping object keys in quotes is not necessary and it doesn't make a difference.
**Side Note**: the [JSON data exchange format](https://www.json.org/json-en.html) _does_ require double quotes around identifiers (and does _not_ allow single quotes).


### semicolons
Some lines were missing it, my prettier automatically added it to them.
